### PR TITLE
BG-12483 add has-tokens feature to coins

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -48,6 +48,7 @@ export const enum CoinFeature {
   CHILD_PAYS_FOR_PARENT = 'cpfp',
   WRAPPED_SEGWIT = 'wrapped-segwit',
   NATIVE_SEGWIT = 'native-segwit',
+  HAS_TOKENS = 'has-tokens',
 }
 
 /**


### PR DESCRIPTION
We need to know if a coin has tokens (i.e. ETH or OFC), so the UI knows when to attempt to read/show tokens and when not.