### PR TITLE
Fix TLTC network

### DIFF
--- a/src/networks.ts
+++ b/src/networks.ts
@@ -82,7 +82,7 @@ class Litecoin extends Mainnet implements UtxoNetwork {
   family = CoinFamily.LTC;
 }
 
-class LitecoinTestnet extends Mainnet implements UtxoNetwork {
+class LitecoinTestnet extends Testnet implements UtxoNetwork {
   bech32 = 'tltc';
   // clarify these constants - they are different between BitGoJS and bitgo-utxo-lib
   bip32 = {


### PR DESCRIPTION
## Changes
The `LitecoinTestnet` class extended `Mainnet`. It should extend `Testnet` instead.

## Motivation 
Fix the bug! 

## Question
How do I test this?