### PR TITLE
BRE-496 Updated version to 1.1.0 as part of the hotfix release rz20190516a.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/statics",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/statics",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "dependency-free static configuration for the bitgo platform",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
[BRE-496](https://bitgoinc.atlassian.net/browse/BRE-496)

Updated @bitgo/statics version to 1.1.0 in both package.json and package-lock.json for a new release.