### PR TITLE
BG-14395: Bump version to 1.5.1 and fix ofcerc network

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/statics",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "dependency-free static configuration for the bitgo platform",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/src/ofc.ts
+++ b/src/ofc.ts
@@ -156,7 +156,7 @@ export function ofcerc20(
   features: CoinFeature[] = OfcCoin.DEFAULT_FEATURES,
   prefix: string = '',
   suffix: string = name.replace(/^ofc/, '').toUpperCase(),
-  network: OfcNetwork = Networks.test.ofc,
+  network: OfcNetwork = Networks.main.ofc,
   isToken: boolean = true,
   addressCoin: string = 'eth',
 ) {


### PR DESCRIPTION
The network config for `ofcerc20` was set to `test` when it should be `main`.