### PR TITLE
TOKS-32 - Add domain property to Stellar tokens

### DIFF
--- a/src/coins.ts
+++ b/src/coins.ts
@@ -331,7 +331,8 @@ export const coins = CoinMap.fromCoins([
     'xlm:VELO-GC7GMEKN2P5LKGOVW55WGHMVQRPPRPHIRFMIC75Z6WPYPYR7B3Z3WEKH',
     'Velo Token',
     7,
-    UnderlyingAsset['xlm:VELO-GC7GMEKN2P5LKGOVW55WGHMVQRPPRPHIRFMIC75Z6WPYPYR7B3Z3WEKH']
+    UnderlyingAsset['xlm:VELO-GC7GMEKN2P5LKGOVW55WGHMVQRPPRPHIRFMIC75Z6WPYPYR7B3Z3WEKH'],
+    'velo.org'
   ),
   terc20('terc', 'ERC Test Token', 0, '0x945ac907cf021a6bcd07852bb3b8c087051706a9', UnderlyingAsset.ERC),
   terc20('test', 'Test Mintable ERC20 Token', 18, '0x1fb879581f31687b905653d4bbcbe3af507bed37', UnderlyingAsset.TEST),

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -40,10 +40,17 @@ export class MissingRequiredCoinFeatureError extends BitGoStaticsError {
   }
 }
 
-export class InvalidContractAddress extends BitGoStaticsError {
+export class InvalidContractAddressError extends BitGoStaticsError {
   public constructor(coinName: string, contractAddress: string) {
     super(`invalid contract address '${contractAddress}' for coin '${coinName}'`);
-    Object.setPrototypeOf(this, InvalidContractAddress.prototype);
+    Object.setPrototypeOf(this, InvalidContractAddressError.prototype);
+  }
+}
+
+export class InvalidDomainError extends BitGoStaticsError {
+  public constructor(coinName: string, domain: string) {
+    super(`invalid domain '${domain}' for coin '${coinName}'`);
+    Object.setPrototypeOf(this, InvalidDomainError.prototype);
   }
 }
 
@@ -52,6 +59,6 @@ export class ConflictingCoinFeaturesError extends BitGoStaticsError {
     super(
       `coin feature(s) for coin '${coinName}' cannot be both required and disallowed: ${conflictingFeatures.join(', ')}`
     );
-    Object.setPrototypeOf(this, InvalidContractAddress.prototype);
+    Object.setPrototypeOf(this, ConflictingCoinFeaturesError.prototype);
   }
 }


### PR DESCRIPTION
Add domain property to Stellar tokens, so that users can access more information about the token from the issuer's `stellar.toml` file. See https://www.stellar.org/developers/guides/concepts/stellar-toml.html

https://bitgoinc.atlassian.net/browse/TOKS-32